### PR TITLE
feat: add search from bytes option and refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
       queryInput.disabled = true;
       output.textContent = "Loading...";
 
-      const engine = await new SearchEngine();
+      let serialized_engine = await fetch("serialized_engine");
+      serialized_engine = await serialized_engine.bytes();
+
+      const engine = await SearchEngine.from_Uint8Array(serialized_engine);
 
       queryInput.disabled = false;
       output.textContent = "";

--- a/justfile
+++ b/justfile
@@ -20,5 +20,6 @@ build-web:
 # serve a web example of the library to localhost. (make sure build-web has been run)
 [working-directory: 'target/wasm']
 serve-example:
+    cp ../../target/data serialized_engine
     cp ../../index.html .
     python3 -m http.server 8001


### PR DESCRIPTION
- search from bytes lets us do fetch API instead of needing to embed the serialized binary with include bytes
- refactored binary main.rs and library lib.rs to make more sense